### PR TITLE
Fix bug for Social Icon

### DIFF
--- a/lib/css/core.css
+++ b/lib/css/core.css
@@ -146,7 +146,7 @@ a.symbol {
 	text-shadow: 1px 1px 0 #111111;
 	font-weight: normal;
 	font-style: normal;
-	font-size: 2em;
+	font-size: 26px;
 	line-height: 1.5;
 	text-align: center;
 }


### PR DESCRIPTION
Fix bug for social icon - When font-size is increase social icons symbols get out of the layout