### PR TITLE
Fix sanitization routines for PHP 7.1

### DIFF
--- a/options/options-sanitize.php
+++ b/options/options-sanitize.php
@@ -86,7 +86,7 @@ add_filter( 'cyberchimps_sanitize_checkbox', 'cyberchimps_sanitize_checkbox' );
 
 /* Multicheck */
 function cyberchimps_sanitize_multicheck( $input, $option ) {
-	$output = '';
+	$output = array();
 	if( is_array( $input ) ) {
 		foreach( $option['options'] as $key => $value ) {
 			$output[$key] = "0";
@@ -185,7 +185,7 @@ function cyberchimps_sanitize_enum( $input, $option ) {
 
 /* Section Order */
 function cyberchimps_sanitize_section_order( $input, $option ) {
-	$output = '';
+	$output = array();
 	if( is_array( $input ) ) {
 		foreach( $input as $key => $value ) {
 			if( array_key_exists( $key, $option['options'] ) && $key ) {


### PR DESCRIPTION
Lines 88 and 188 in [options/options-sanitize.php](https://github.com/cyberchimps/core/blob/master/options/options-sanitize.php) set `$output` to an empty string, and subsequent lines in `cyberchimps_sanitize_multicheck` and `cyberchimps_sanitize_section_order` add items to these lists as if they were arrays. In PHP 7.1, this triggers a fatal error:

```
Fatal error: Uncaught Error: [] operator not supported for strings
```

This PR fixes the issue.